### PR TITLE
Fixed#22

### DIFF
--- a/src/scss/volt/_variables.scss
+++ b/src/scss/volt/_variables.scss
@@ -876,7 +876,7 @@ $custom-toggle-disabled-bg:                     $gray-200;
 $custom-toggle-disabled-checked-bg:             rgba($primary, .7);
 $custom-toggle-border-radius:                   .8rem;
 
-$custom-switch-indicator-size:                  calc(#{$custom-control-indicator-size} - #{$custom-control-indicator-border-width * 4});
+$custom-switch-indicator-size: math.div($custom-control-indicator-size, 4) - $custom-control-indicator-border-width * 4;
 
 $custom-checkbox-disabled-checked-color:        $gray-800;
 


### PR DESCRIPTION
Addressed deprecation warning in Sass code related to the use of the forward slash (/) for division outside of the `calc()` function. Replaced instances with the recommended syntax `math.div($spacer, 4)` or `calc($spacer / 4)`. This change resolves the issue "fixed22" in the open-source project.

